### PR TITLE
Add some UIImage helper functions that return an image with a border or background drawn in

### DIFF
--- a/Sources/UIImage+Effects.swift
+++ b/Sources/UIImage+Effects.swift
@@ -84,10 +84,10 @@ extension UIImage {
        - color:     The color for the border.
        - size:      The size of the image.
        - radius:    The radius used if drawing rounded corners. Defaults to 0.
-       - isDashed:  A boolean that states if the drawn border is solid or dashed. Defaults to false.
+       - isDashed:  A boolean that states if the drawn border is solid or dashed.
      - Returns:     Returns an image with a solid color of the given size.
     */
-    public convenience init(color: UIColor, size: CGSize, radius: CGFloat = 0, isDashed: Bool = false) throws {
+    public convenience init(color: UIColor, size: CGSize, radius: CGFloat = 0, isDashed: Bool) throws {
         let scale = UIScreen.main.scale
         UIGraphicsBeginImageContextWithOptions(size, false, scale)
         defer { UIGraphicsEndImageContext() }
@@ -114,6 +114,45 @@ extension UIImage {
             throw ImageError.CantCreateImage
         }
         self.init(cgImage: cgimage, scale: scale, orientation: .up)
+    }
+
+    /**
+     Returns an image with a background of given size and color, with a border respecting the given radius.
+
+     - Parameters:
+       - icon:             The main image to add a background to.
+       - backgroundColor:  The color for the background.
+       - size:             The size of the background.
+       - radius:           The radius used if drawing rounded corners. Defaults to 0.
+     - Returns:            Returns an image with a solid color of the given size.
+    */
+
+    public static func iconWithBackground(_ icon: UIImage, backgroundColor: UIColor, size: CGSize, radius: CGFloat = 0) -> UIImage {
+
+        let backgroundImage = try? UIImage(color: backgroundColor, size: size, radius: radius)
+        let modifiedImage = try? backgroundImage?.union(icon)
+
+        return modifiedImage ?? icon
+    }
+
+    /**
+     Returns an image with a border of given size and color, and respecting the given radius.
+
+     - Parameters:
+       - icon:            The main image to add a background to.
+       - borderColor:     The color for the background.
+       - size:            The size of the background.
+       - radius:          The radius used if drawing rounded corners. Defaults to 0.
+       - isDashed:        A boolean that states if the drawn border is solid or dashed.
+     - Returns:           Returns an image with a border of the given color and size.
+    */
+
+    public static func iconWithBorder(_ icon: UIImage, borderColor: UIColor, size: CGSize, radius: CGFloat = 0, isDashed: Bool) -> UIImage {
+
+        let backgroundImage = try? UIImage(color: borderColor, size: size, radius: radius, isDashed: isDashed)
+        let modifiedImage = try? backgroundImage?.union(icon)
+
+        return modifiedImage ?? icon
     }
 
     /**

--- a/Sources/UIImage+Effects.swift
+++ b/Sources/UIImage+Effects.swift
@@ -38,10 +38,27 @@ extension CGRect {
 extension UIImage {
 
     /**
+     Returns a UIImage from another UIImage.
+
+     - Parameters:
+     - image:             The image to copy.
+     - Returns:             A UIImage.
+     */
+    public convenience init(_ image: UIImage) {
+        if let cgimage = image.cgImage {
+            self.init(cgImage: cgimage, scale: image.scale, orientation: image.imageOrientation)
+        }
+        if let ciimage = image.ciImage {
+            self.init(ciImage: ciimage, scale: image.scale, orientation: image.imageOrientation)
+        }
+        fatalError("Unknown image type: \(image.debugDescription).")
+    }
+
+    /**
      Returns a solid color image with the given rectangle size.
 
      - Parameters:
-       - color:     The color for the image.
+     - color:     The color for the image.
        - size:      The size of the image.
        - radius:    The radius used if drawing rounded corners. Defaults to nil.
      - Returns:     Returns an image with a solid color of the given size.
@@ -120,30 +137,27 @@ extension UIImage {
      Returns an image with a background of given size and color, with a border respecting the given radius.
 
      - Parameters:
-       - icon:             The main image to add a background to.
-       - backgroundColor:  The color for the background.
-       - size:             The size of the background.
-       - radius:           The radius used if drawing rounded corners. Defaults to 0.
+     - icon:             The main image to add a background to.
+     - backgroundColor:  The color for the background.
+     - size:             The size of the background.
+     - radius:           The radius used if drawing rounded corners. Defaults to 0.
      - Returns:            Returns an image with a solid color of the given size.
-    */
-
-    public static func iconWithBackground(_ icon: UIImage, backgroundColor: UIColor, size: CGSize, radius: CGFloat = 0) -> UIImage {
-
+     */
+    public convenience init(icon: UIImage, backgroundColor: UIColor, size: CGSize, radius: CGFloat = 0) {
         let backgroundImage = try? UIImage(color: backgroundColor, size: size, radius: radius)
-        let modifiedImage = try? backgroundImage?.union(icon)
-
-        return modifiedImage ?? icon
+        let modifiedImage: UIImage = (try? backgroundImage?.union(icon)) ?? icon
+        self.init(modifiedImage)
     }
 
     /**
      Returns an image with a border of given size and color, and respecting the given radius.
 
      - Parameters:
-       - icon:            The main image to add a background to.
-       - borderColor:     The color for the background.
-       - size:            The size of the background.
-       - radius:          The radius used if drawing rounded corners. Defaults to 0.
-       - isDashed:        A boolean that states if the drawn border is solid or dashed.
+     - icon:            The main image to add a background to.
+     - borderColor:     The color for the background.
+     - size:            The size of the background.
+     - radius:          The radius used if drawing rounded corners. Defaults to 0.
+     - isDashed:        A boolean that states if the drawn border is solid or dashed.
      - Returns:           Returns an image with a border of the given color and size.
     */
 

--- a/Sources/UIImage+Effects.swift
+++ b/Sources/UIImage+Effects.swift
@@ -47,9 +47,11 @@ extension UIImage {
     public convenience init(_ image: UIImage) {
         if let cgimage = image.cgImage {
             self.init(cgImage: cgimage, scale: image.scale, orientation: image.imageOrientation)
+            return
         }
         if let ciimage = image.ciImage {
             self.init(ciImage: ciimage, scale: image.scale, orientation: image.imageOrientation)
+            return
         }
         fatalError("Unknown image type: \(image.debugDescription).")
     }

--- a/Sources/ViewController.swift
+++ b/Sources/ViewController.swift
@@ -34,6 +34,7 @@ class ViewController: UIViewController {
             plainLogoView(),
             enhancedLogoView(),
             composedLogoView(),
+            iconWithBackground(name: "icon_calculator_grayscale"),
             iconWithRoundedRectangle(name: "icon_calculator_grayscale"),
             iconInView(name: "icon_briefcase_grayscale", scheme: .grayscale),
             iconInView(name: "icon_briefcase_grayscale", scheme: .inverse),
@@ -115,5 +116,11 @@ class ViewController: UIViewController {
 
         let newImage = try? image?.union(icon)
         return LabeledImage(text: "Icon with oval background", image: newImage!)
+    }
+
+    private func iconWithBackground(name: String) -> UIView {
+        let icon = AFIcon.named(name, scheme: .grayscale, size: CGSize(width: 50, height: 50))
+        let modifiedImage = UIImage.icon(icon, backgroundColor: .yellow, size: CGSize(width: 200, height: 92), radius: 50)
+        return LabeledImage(text: "Icon with solid background", image: modifiedImage)
     }
 }

--- a/Sources/ViewController.swift
+++ b/Sources/ViewController.swift
@@ -120,7 +120,7 @@ class ViewController: UIViewController {
 
     private func iconWithBackground(name: String) -> UIView {
         let icon = AFIcon.named(name, scheme: .grayscale, size: CGSize(width: 50, height: 50))
-        let modifiedImage = UIImage.icon(icon, backgroundColor: .yellow, size: CGSize(width: 200, height: 92), radius: 50)
+        let modifiedImage = UIImage(icon: icon, backgroundColor: .yellow, size: CGSize(width: 200, height: 92), radius: 50)
         return LabeledImage(text: "Icon with solid background", image: modifiedImage)
     }
 }


### PR DESCRIPTION
Curious to know how you envisioned making these functions convenience inits instead; I have no idea how that's supposed to look. Also, should I be throwing errors with the helpers inside this extension rather than failing gracefully? I feel like I should...